### PR TITLE
Fix/readme duplication

### DIFF
--- a/__tests__/auto-readme-creator.test.js
+++ b/__tests__/auto-readme-creator.test.js
@@ -42,7 +42,6 @@ test('generates README.md with correct headings and paragraphs', () => {
   // Run the auto-readme-creator script
   execSync('node ./index.js', { stdio: 'inherit' });
 
-
   const readmeContent = fs.readFileSync(readmePath, 'utf-8');
 
   expect(readmeContent).toContain('# test-file');
@@ -52,4 +51,53 @@ test('generates README.md with correct headings and paragraphs', () => {
   expect(readmeContent).toContain('## User Input Handling');
   expect(readmeContent).toContain('This section processes user inputs');
   expect(readmeContent).toContain('It validates and formats inputs before they are used');
+});
+
+test('updates README.md when file content changes without duplicating', () => {
+  // Initial content of the file
+  const initialContent = `
+// Initialization
+// ~ This function sets up the application environment
+`;
+
+  createTestFile(initialContent);
+
+  // Run the auto-readme-creator script initially
+  execSync('node ./index.js', { stdio: 'inherit' });
+
+  let readmeContent = fs.readFileSync(readmePath, 'utf-8');
+
+  // Ensure the initial README content is correct
+  expect(readmeContent).toContain('# test-file');
+  expect(readmeContent).toContain('## Initialization');
+  expect(readmeContent).toContain('This function sets up the application environment');
+
+  // Modify the file content to simulate a file change
+  const updatedContent = `
+// Initialization
+// ~ This function sets up the application environment
+// ~ It includes loading configurations
+
+// User Input Handling
+// ~ This section handles user inputs
+`;
+
+  createTestFile(updatedContent);
+
+  // Re-run the auto-readme-creator script after file change
+  execSync('node ./index.js', { stdio: 'inherit' });
+
+  readmeContent = fs.readFileSync(readmePath, 'utf-8');
+
+  // Ensure the old content is replaced, and new content is added without duplication
+  expect(readmeContent).toContain('It includes loading configurations');
+  expect(readmeContent).toContain('## User Input Handling');
+  expect(readmeContent).toContain('This section handles user inputs');
+
+  // Check that duplicate sections do not exist
+  const initHeadingMatches = (readmeContent.match(/## Initialization/g) || []).length;
+  expect(initHeadingMatches).toBe(1);
+
+  const userHandlingMatches = (readmeContent.match(/## User Input Handling/g) || []).length;
+  expect(userHandlingMatches).toBe(1);
 });

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ const generateMarkdown = (comments, fileName) => {
   // Extract the base name without extension for section title
   const baseName = path.basename(fileName, path.extname(fileName));
 
-  let markdown = `# ${baseName}\n\n`;
+  let markdown = `<!-- START ${baseName.toUpperCase()} SECTION -->\n`;
+  markdown += `# ${baseName}\n\n`;
+
   let currentHeading = null;
 
   comments.forEach(comment => {
@@ -65,6 +67,8 @@ const generateMarkdown = (comments, fileName) => {
     markdown += `No comments found in ${fileName}.\n\n`;
   }
 
+  markdown += `<!-- END ${baseName.toUpperCase()} SECTION -->\n\n`;
+
   return markdown;
 };
 
@@ -77,14 +81,15 @@ const updateReadme = (fileName, markdownContent) => {
     readmeContent = fs.readFileSync('README.md', 'utf-8');
   }
 
-  const fileSection = `# ${path.basename(fileName, path.extname(fileName))}\n`;
+  const sectionStart = `<!-- START ${path.basename(fileName, path.extname(fileName)).toUpperCase()} SECTION -->`;
+  const sectionEnd = `<!-- END ${path.basename(fileName, path.extname(fileName)).toUpperCase()} SECTION -->`;
 
   // Replace existing content for the file if it already exists
-  if (readmeContent.includes(fileSection)) {
-    const regex = new RegExp(`${fileSection}[\\s\\S]*?(?=# |$)`, 'g');
+  const regex = new RegExp(`${sectionStart}[\\s\\S]*?${sectionEnd}`, 'g');
+  if (readmeContent.match(regex)) {
     readmeContent = readmeContent.replace(regex, markdownContent);
   } else {
-    // Append new content
+    // Append new content at the end
     readmeContent += markdownContent;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-readme-creator",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-readme-creator",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.14.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-readme-creator",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "A CLI tool to automatically generate README.md files based on comments in your code.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This pull request addresses the issue of redundant content being added to the README file when code changes are made.

1. I modified the `updateReadme` function to ensure that it replaces existing content in the README file if the section for that file already exists.
2. I ran tests to verify that the README is updated correctly when functions are changed, ensuring no duplication occurs. All tests passed successfully.

### Related Issues
Fixes #1  
